### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.7
+
+WORKDIR /app
+COPY app/Gemfile* ./
+RUN bundle install
+
+COPY app /app
+
+RUN ln -s /app/bin/buildkite-compat /bin/buildkite-compat
+
+WORKDIR /
+ENTRYPOINT buildkite-compat


### PR DESCRIPTION
Adds a Dockerfile so we can run compat using Buildkite On-Demand, this is published to the keithduncan/buildkite-compat Docker Hub repository for now.