### PR TITLE
Add support for an On-Demand backend

### DIFF
--- a/app/lib/bk/compat/circleci.rb
+++ b/app/lib/bk/compat/circleci.rb
@@ -12,9 +12,10 @@ module BK
         keys.include?("version") && keys.include?("jobs")
       end
 
-      def initialize(text)
+      def initialize(text, options)
         @config = YAML.safe_load(text)
         @now = Time.now
+        @options = options
       end
 
       def parse

--- a/app/lib/bk/compat/circleci.rb
+++ b/app/lib/bk/compat/circleci.rb
@@ -12,7 +12,7 @@ module BK
         keys.include?("version") && keys.include?("jobs")
       end
 
-      def initialize(text, options)
+      def initialize(text, options = {})
         @config = YAML.safe_load(text)
         @now = Time.now
         @options = options

--- a/app/lib/bk/compat/cli.rb
+++ b/app/lib/bk/compat/cli.rb
@@ -5,6 +5,10 @@ module BK
       require "optparse"
 
       def self.run(command_line)
+        options = {
+          runner: "ELASTIC_CI",
+        }
+
         option_parser = OptionParser.new do |opts|
           opts.program_name = "buildkite-compat"
           opts.version = BK::Compat::VERSION
@@ -18,6 +22,9 @@ module BK
               $ cat [file] > buildkite-compat [options]
 
           BANNER
+          opts.on("-r", "--runner=", "Which runner to target, ELASTIC_CI or ON_DEMAND") do |r|
+            options[:runner] = r
+          end
         end
 
         option_parser.parse!
@@ -49,7 +56,7 @@ module BK
         end
 
         # Now we can finally parse and render the thing
-        puts parser_klass.new(text).parse.render
+        puts parser_klass.new(text, options).parse.render
       end
     end
   end

--- a/app/lib/bk/compat/pipeline.rb
+++ b/app/lib/bk/compat/pipeline.rb
@@ -22,11 +22,12 @@ module BK
       end
 
       class CommandStep
-        attr_accessor :label, :key, :commands, :plugins, :depends_on, :soft_fail, :env, :conditional
+        attr_accessor :label, :key, :commands, :agents, :plugins, :depends_on, :soft_fail, :env, :conditional
 
-        def initialize(label: nil, key: nil, commands: [], plugins: [], depends_on: nil, soft_fail: nil, env: nil, conditional: nil)
+        def initialize(label: nil, key: nil, agents: [], commands: [], plugins: [], depends_on: nil, soft_fail: nil, env: nil, conditional: nil)
           self.label = label
           self.commands = commands
+          self.agents = agents
           self.key = key
           self.plugins = plugins
           self.depends_on = depends_on
@@ -51,6 +52,7 @@ module BK
           {}.tap do |h|
             h[:key] = @key if @key
             h[:label] = @label if @label
+            h[:agents] = @agents unless @agents.empty?
             if @commands.is_a?(Array)
               if @commands.length == 1
                 h[:command] = @commands.first

--- a/app/lib/bk/compat/renderer.rb
+++ b/app/lib/bk/compat/renderer.rb
@@ -14,7 +14,7 @@ module BK
         @structure = structure
       end
 
-      def render(colors: true, format: Format::YAML)
+      def render(colors: STDOUT.tty?, format: Format::YAML)
         case format
         when Format::YAML
           text = JSON.parse(@structure.to_json).to_yaml

--- a/app/lib/bk/compat/travisci.rb
+++ b/app/lib/bk/compat/travisci.rb
@@ -12,8 +12,9 @@ module BK
         keys.include?("language") || keys.include?("rvm")
       end
 
-      def initialize(text)
+      def initialize(text, options)
         @config = YAML.safe_load(text)
+        @options = options
       end
 
       SOURCES = {

--- a/app/lib/bk/compat/travisci.rb
+++ b/app/lib/bk/compat/travisci.rb
@@ -140,14 +140,21 @@ module BK
               }
             )
 
-            bk_step.plugins << BK::Compat::Pipeline::Plugin.new(
-              path: "docker#v3.3.0",
-              config: {
-                image: docker_image,
-                workdir: "/buildkite-checkout",
-                "propagate-environment": true
-              }
-            )
+            case @options[:runner]
+            when "ELASTIC_CI"
+              bk_step.plugins << BK::Compat::Pipeline::Plugin.new(
+                path: "docker#v3.3.0",
+                config: {
+                  image: docker_image,
+                  workdir: "/buildkite-checkout",
+                  "propagate-environment": true
+                }
+              )
+            when "ON_DEMAND"
+              bk_step.agents << "image=#{docker_image}"
+            else
+              raise BK::Compat::Error::NotSupportedError.new("runner: #{@options[:runner]} is not supported")
+            end
           else
             bk_step = BK::Compat::Pipeline::CommandStep.new(
               label: ":travisci: #{version} (no docker image)",

--- a/app/lib/bk/compat/travisci.rb
+++ b/app/lib/bk/compat/travisci.rb
@@ -12,7 +12,7 @@ module BK
         keys.include?("language") || keys.include?("rvm")
       end
 
-      def initialize(text, options)
+      def initialize(text, options = {})
         @config = YAML.safe_load(text)
         @options = options
       end

--- a/app/lib/bk/compat/travisci.rb
+++ b/app/lib/bk/compat/travisci.rb
@@ -140,7 +140,7 @@ module BK
               }
             )
 
-            case @options[:runner]
+            case @options.fetch(:runner, "ELASTIC_CI")
             when "ELASTIC_CI"
               bk_step.plugins << BK::Compat::Pipeline::Plugin.new(
                 path: "docker#v3.3.0",


### PR DESCRIPTION
This adds a `--runner` command line argument so that the CLI can generate a pipeline that targets Buildkite On-Demand.

The difference is whether to use the `docker` plugin or an `agent: image: #{docker_image}` agent query rule for a dynamic task definition.

I’m not tied to this approach and feel it has some flaws. I’d like to handle the default option of `ELASTIC_CI` better rather than down in the individual parser. I’m also wondering whether we can express the difference in elastic-ci vs on-demand in a way that can be handled at serialisation time so the underlying platform doesn’t have to know. A second tier parser that converts the `BK::Compat::Pipeline` into one for Elastic CI or On-Demand?