### PR TITLE
add support for anchors in circle ci yaml files

### DIFF
--- a/app/lib/bk/compat/circleci.rb
+++ b/app/lib/bk/compat/circleci.rb
@@ -8,12 +8,12 @@ module BK
       end
 
       def self.matches?(text)
-        keys = YAML.safe_load(text).keys
+        keys = YAML.safe_load(text, aliases: true).keys
         keys.include?("version") && keys.include?("jobs")
       end
 
       def initialize(text, options = {})
-        @config = YAML.safe_load(text)
+        @config = YAML.safe_load(text, aliases: true)
         @now = Time.now
         @options = options
       end


### PR DESCRIPTION
Circle CI allows anchors in the YAML.  This enables aliases and anchors in parsing circle CI files.

https://circleci.com/docs/2.0/writing-yaml/