### PR TITLE
Adding approval conversion support

### DIFF
--- a/app/lib/bk/compat/circleci.rb
+++ b/app/lib/bk/compat/circleci.rb
@@ -61,7 +61,11 @@ module BK
                 steps_by_key.fetch(j)
               when Hash
                 key = j.keys.first
-                step = steps_by_key.fetch(key).dup
+                if j[key]['type'] == "approval"
+                  step = BK::Compat::Pipeline::BlockStep.new(key: key, label: ":circleci: #{key}", prompt: key)
+                else
+                  step = steps_by_key.fetch(key).dup
+                end
 
                 if requires = j[key]["requires"]
                   step.depends_on = [*requires]

--- a/app/lib/bk/compat/pipeline.rb
+++ b/app/lib/bk/compat/pipeline.rb
@@ -69,6 +69,25 @@ module BK
         end
       end
 
+      class BlockStep
+        attr_accessor :label, :type, :key, :prompt, :fields, :branches, :depends_on
+
+        def initialize(label: nil, key: nil, prompt: nil, fields: [], depends_on: nil)
+          @label = label
+          @prompt = prompt
+          @key = key
+          @fields = fields
+          @depends_on = depends_on
+        end
+
+        def to_h
+          { label: @label, type: 'block', key: @key, prompt: @prompt }.tap do |h|
+            h[:depends_on] = @depends_on if @depends_on
+            h[:fields] = @fields.map(&:to_h) if @fields && !@fields.empty?
+          end
+        end
+      end
+
       class GroupStep
         attr_accessor :label, :key, :steps, :conditional
 


### PR DESCRIPTION
Currently for non-command steps the conversion process fails when it comes
across an approval. This change handles the approval step and allows it to
converted to the appropriate buildkite primitive.

This change is not fully complete, but it will at least create valid block steps and
not error out when an approval step is used. 